### PR TITLE
Enforce hard-tab use

### DIFF
--- a/settings/language-68hc11-assembly.cson
+++ b/settings/language-68hc11-assembly.cson
@@ -4,3 +4,4 @@
 '.source.68hc11-assembly':
   'editor':
     'commentStart': '; '
+    'tabType': 'hard'


### PR DESCRIPTION
It's possible to set indentation styles at an editor level based on its grammar (Atom's [Makefile](https://github.com/atom/language-make/blob/master/settings/language-make.cson) grammar does it, for instance).

Which is exactly what this PR does: automatically set an editor's tab-style to hard-tabs if 68HC11 assembly is used as its grammar.